### PR TITLE
Update deprecated time unit

### DIFF
--- a/lib/plug_session_mnesia/cleaner.ex
+++ b/lib/plug_session_mnesia/cleaner.ex
@@ -62,7 +62,7 @@ defmodule PlugSessionMnesia.Cleaner do
 
   def clean_sessions(table, max_age) do
     oldest_timestamp =
-      System.os_time() - System.convert_time_unit(max_age, :seconds, :native)
+      System.os_time() - System.convert_time_unit(max_age, :second, :native)
 
     delete_old_sessions = fn ->
       old_sids =


### PR DESCRIPTION
Hi @ejpcmac,

Thanks for your work. I believe this library deserves bigger credit and exposure, personally it's going to be my go-to choice in future.

This PR just removes deprecation warning by renaming `seconds` to `second` as per warning message https://github.com/elixir-lang/elixir/blob/3c9ff7b1aea00667f32253ecafe4c6fea23982ff/lib/elixir/lib/system.ex#L1073