### PR TITLE
Update deprecated time unit

### DIFF
--- a/lib/plug_session_mnesia/cleaner.ex
+++ b/lib/plug_session_mnesia/cleaner.ex
@@ -62,7 +62,7 @@ defmodule PlugSessionMnesia.Cleaner do
 
   def clean_sessions(table, max_age) do
     oldest_timestamp =
-      System.os_time() - System.convert_time_unit(max_age, :seconds, :native)
+      System.os_time() - System.convert_time_unit(max_age, :second, :native)
 
     delete_old_sessions = fn ->
       old_sids =


### PR DESCRIPTION
Re-open a pull request to merge in `develop` instead of `master`, which is reserved for releases. I mistakenly accepted #3 which was not on the correct branch and force-pushed `master` in seconds.